### PR TITLE
feat: add automatic Google Calendar integration for IT quiz announcements

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,7 +11,7 @@ export default [
 			},
 		},
 		plugins: {
-			canonical, 
+			canonical,
 		},
 		rules: {
 			'no-dupe-class-members': 'off',
@@ -19,6 +19,7 @@ export default [
 			'import/no-namespace': 'off',
 			'canonical/require-extension': 'error',
 			'@typescript-eslint/no-explicit-any': 'warn',
+			'import/no-named-as-default-member': 'off',
 		},
 	},
 ];

--- a/functions/src/const.ts
+++ b/functions/src/const.ts
@@ -12,3 +12,5 @@ export const EXPIRATION_WINDOW_IN_SECONDS = 300;
 export const BILLBOARD_HOT100_ID = 'UCP3UgSH9dDuanz7cDAIkHxA.nGzAI5pLbMY';
 export const IT_QUIZ_GOOGLE_SHEET_ID = '1OjcWGGyEdqYBYXSSeF3iOXqHXJJdvcCpfjL22e2zKZU';
 export const IT_QUIZ_YOUTUBE_CHANNEL_ID = 'UCmGXjoj98-4jDsR3ebWMP7A';
+export const SIG_QUIZ_CHANNEL_ID = 'C02DCA8D0DT';
+export const TSG_EVENTS_CALENDAR_ID = 'hl5mthjments725aadepplvcvs@group.calendar.google.com';


### PR DESCRIPTION
Add functionality to automatically create Google Calendar events when IT quiz announcements are posted in #sig-quiz channel by @hakatashi.

Features:
- Parse messages containing "ITクイズ" and "やります" with time patterns
- Support both "今日" (today) and "明日" (tomorrow) announcements
- Create calendar events in TSG Events calendar with detailed description
- Use dayjs with Asia/Tokyo timezone for accurate time handling
- Add Discord event link as event location
- React with :calendar: on success, :x: on failure

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>