### PR TITLE
feat: add Google Calendar scope to OAuth authentication

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -21,6 +21,7 @@ export const authenticateGoogleApi = onRequest((request, response) => {
 			'https://www.googleapis.com/auth/userinfo.profile',
 			'https://www.googleapis.com/auth/youtube.readonly',
 			'https://www.googleapis.com/auth/spreadsheets.readonly',
+			'https://www.googleapis.com/auth/calendar',
 		],
 	});
 	response.redirect(url);


### PR DESCRIPTION
Add 'https://www.googleapis.com/auth/calendar' scope to Google OAuth authentication to enable calendar read/write permissions for IT quiz calendar integration feature.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>