### PR TITLE
config: increase memory allocation for wordblog cron function

### DIFF
--- a/functions/src/crons/wordblog.ts
+++ b/functions/src/crons/wordblog.ts
@@ -271,6 +271,7 @@ export const updateWordBlog = onSchedule(
 		timeoutSeconds: 120,
 		schedule: '0 10 * * *',
 		timeZone: 'Asia/Tokyo',
+		memory: '512MiB',
 	},
 	updateWordBlogFunction,
 );


### PR DESCRIPTION
Add memory: '512MiB' configuration to updateWordBlog scheduled function
to handle increased memory requirements for word blog processing.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>